### PR TITLE
Updates for Notify use cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ### Terraform ###
 # Local .terraform directories
 **/.terraform/*
+.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ backend.tfvars
 
 terraform/provision/.terraform.lock.hcl
 *.binding.json
+*.provisioning.txt

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ demo-up: ## Provision an SMTP instance and output the bound credentials
 	set -e ;\
 	eval "$$( $(CSB_SET_IDS) )" ;\
 	echo "Provisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
-	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                     --params $(CLOUD_PROVISION_PARAMS) 2>&1 > /dev/null ;\
+	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                     --params $(CLOUD_PROVISION_PARAMS) 2>&1 > ${INSTANCE_NAME}.provisioning.txt ;\
 	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} ;\
 	echo "Binding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding1" ;\
 	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding1 --params $(CLOUD_BIND_PARAMS) | jq -r .response > ${INSTANCE_NAME}.binding.json ;\
@@ -115,7 +115,7 @@ demo-up-supplied: ## Provision an SMTP instance and output the bound credentials
 	set -e ;\
 	eval "$$( $(CSB_SET_IDS) )" ;\
 	echo "Provisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
-	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params '{ "domain": "test.com", "create_sns_topics": true }' 2>&1 > /dev/null ;\
+	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params '{ "domain": "test.com", "create_sns_topics": true }' 2>&1 > ${INSTANCE_NAME}.provisioning.txt ;\
 	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} ;\
 	echo "Binding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding2" ;\
 	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding2 --params '{}' | jq -r .response > ${INSTANCE_NAME}.binding.json ;\
@@ -138,12 +138,12 @@ demo-down: ## Clean up data left over from tests and demos
 	@( \
 	set -e ;\
 	eval "$$( $(CSB_SET_IDS) )" ;\
-	echo "Unbinding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding1" ;\
-	$(CSB_EXEC) client unbind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding1 2>&1 > /dev/null || true ;\
-	echo "Unbinding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding2" ;\
-	$(CSB_EXEC) client unbind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding2 2>&1 > /dev/null || true ;\
-	echo "Deprovisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
-	$(CSB_EXEC) client deprovision   --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} 2>&1 > /dev/null || true ;\
+	echo "Unbinding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding1" || tee -a ${INSTANCE_NAME}.binding.json ;\
+	$(CSB_EXEC) client unbind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding1 2>&1 >> ${INSTANCE_NAME}.binding.json || true ;\
+	echo "Unbinding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding2" || tee -a ${INSTANCE_NAME}.binding.json ;\
+	$(CSB_EXEC) client unbind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding2 2>&1 >> ${INSTANCE_NAME}.binding.json || true ;\
+	echo "Deprovisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" || tee -a ${INSTANCE_NAME}.provisioning.txt ;\
+	$(CSB_EXEC) client deprovision   --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} 2>&1 >> ${INSTANCE_NAME}.provisioning.txt || true ;\
 	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} || true;\
 	)
 

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ demo-up-supplied: ## Provision an SMTP instance and output the bound credentials
 	set -e ;\
 	eval "$$( $(CSB_SET_IDS) )" ;\
 	echo "Provisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
-	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params '{ "domain": "test.com" }' 2>&1 > /dev/null ;\
+	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params '{ "domain": "test.com", "create_sns_topics": true }' 2>&1 > /dev/null ;\
 	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} ;\
 	echo "Binding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding2" ;\
 	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding2 --params '{}' | jq -r .response > ${INSTANCE_NAME}.binding.json ;\
@@ -159,4 +159,3 @@ all: clean build up test down ## Clean and rebuild, then bring up the server, ru
 .PHONY: help
 help: ## This help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-10s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
-

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+checkdmarc = "==4.4.2"
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,103 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "87931484c7c20b29e1a5257011f87c3f1e13f51045e2273178f9115c447372a2"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.9.24"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.1.1"
+        },
+        "checkdmarc": {
+            "hashes": [
+                "sha256:873bbbac92e5ff054d0d84d4ebb8939eda9677a915620d5cd40dd01f36d6f161",
+                "sha256:cba38c80702eb98c38c3afb21ba5af26a0a0bf73bddd08fb2ce3ca9a051df8eb"
+            ],
+            "index": "pypi",
+            "version": "==4.4.2"
+        },
+        "dnspython": {
+            "hashes": [
+                "sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e",
+                "sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "version": "==2.2.1"
+        },
+        "expiringdict": {
+            "hashes": [
+                "sha256:09a5d20bc361163e6432a874edd3179676e935eb81b925eccef48d409a8a45e8",
+                "sha256:300fb92a7e98f15b05cf9a856c1415b3bc4f2e132be07daa326da6414c23ee09"
+            ],
+            "version": "==1.2.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.4"
+        },
+        "publicsuffix2": {
+            "hashes": [
+                "sha256:00f8cc31aa8d0d5592a5ced19cccba7de428ebca985db26ac852d920ddd6fe7b",
+                "sha256:786b5e36205b88758bd3518725ec8cfe7a8173f5269354641f581c6b80a99893"
+            ],
+            "version": "==2.20191221"
+        },
+        "pyleri": {
+            "hashes": [
+                "sha256:24e972792cc1603956495814413b1408ba69573f6a9d8aca1a1830479eb1e5d9"
+            ],
+            "version": "==1.4.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==2.28.1"
+        },
+        "timeout-decorator": {
+            "hashes": [
+                "sha256:6a2f2f58db1c5b24a2cc79de6345760377ad8bdc13813f5265f6c3e63d16b3d7"
+            ],
+            "version": "==0.5.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.12"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -23,9 +23,29 @@ Each brokered AWS SES instance provides:
 
 - If no domain is specified
   - SMTP credentials for sending mail from an auto-generated subdomain (suitable for development)
+  - Bounce, Complaint, and Delivery notifications can be sent to your server. See [Delivery Notifications](#delivery-notifications) for instructions
 - If a domain is specified
   - SMTP credentials for sending mail from the supplied domain
   - DNS records necessary for verifying domain ownership (TXT and DKIM)
+  - Bounce, Complaint, and Delivery notifications can be sent to your server. See [Delivery Notifications](#delivery-notifications) for instructions
+
+### Delivery Notifications
+
+[SES Delivery Notifications](https://docs.aws.amazon.com/ses/latest/dg/monitor-sending-activity-using-notifications-sns.html) can be configured by adding `notification_webhook: ` to the bind parameters.
+
+* The webhook must be an HTTPS endpoint, accessible to the internet.
+* [Documentation on message contents](https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html)
+* **Important** the endpoint must be ready to [confirm the subscription](https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.confirm.html) during the bind process. Here is [an example](https://github.com/GSA/notifications-api/blob/d83a4331263d434ba1415ce652ed70737acd5e9f/app/notifications/sns_handlers.py#L51) of the confirmation process.
+
+Example manifest.yml:
+```
+services:
+  - name: smtp-service
+    parameters:
+      notification_webhook: https://my.server.gov/notifications/ses
+```
+
+If you are sure that you will not be using feedback notifications, you can prevent the SNS topics from being created by adding `"enable_feedback_notifications": false` to the provisioning parameters
 
 ## Development Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ services:
       notification_webhook: https://my.server.gov/notifications/ses
 ```
 
+Included in the bind credentials will be the Amazon ARNs for `bounce_topic_arn`, `complaint_topic_arn`, and `delivery_topic_arn`. These can be used to
+validate the incoming webhooks as coming from the correct source, and help determine between the three message types your webhook will be receiving. They can
+be ignored if you are not using the feedback notifications.
+
 If you are sure that you will not be using feedback notifications, you can prevent the SNS topics from being created by adding `"enable_feedback_notifications": false` to the provisioning parameters
 
 ## Development Prerequisites

--- a/permission-policies.tf
+++ b/permission-policies.tf
@@ -92,7 +92,11 @@ module "smtp_broker_policy" {
               "sns:DeleteTopic",
               "sns:SetTopicAttributes",
               "sns:GetTopicAttributes",
-              "sns:ListTagsForResource"
+              "sns:ListTagsForResource",
+
+              "sns:Subscribe",
+              "sns:Unsubscribe",
+              "sns:GetSubscriptionAttributes"
           ],
           "Resource": "*"
         }

--- a/permission-policies.tf
+++ b/permission-policies.tf
@@ -1,5 +1,5 @@
 # This Terraform code will create an AWS user named "ssb-smtp-broker" with the
-# minimum policies in place that are needed for this brokerpak to operate. 
+# minimum policies in place that are needed for this brokerpak to operate.
 
 locals {
   this_aws_account_id    = data.aws_caller_identity.current.account_id
@@ -82,6 +82,17 @@ module "smtp_broker_policy" {
           "Effect": "Allow",
           "Action": [
               "route53:ListHostedZones"
+          ],
+          "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+              "sns:CreateTopic",
+              "sns:DeleteTopic",
+              "sns:SetTopicAttributes",
+              "sns:GetTopicAttributes",
+              "sns:ListTagsForResource"
           ],
           "Resource": "*"
         }

--- a/smtp.yml
+++ b/smtp.yml
@@ -66,7 +66,6 @@ provision:
     overwrite: true
     type: object
   - name: instance_name
-    required: true
     type: string
     default: ${request.instance_id}
   template_refs:
@@ -122,7 +121,6 @@ bind:
     overwrite: true
     type: string
   - name: instance_name
-    required: true
     type: string
     default: ${request.instance_id}
   - name: bounce_topic_arn

--- a/smtp.yml
+++ b/smtp.yml
@@ -52,21 +52,10 @@ provision:
       type: string
       details: Email to recieve DMARC errors
       default: "datagovhelp@gsa.gov"
-    - field_name: create_sns_topics
+    - field_name: enable_feedback_notifications
       type: boolean
       details: Flag to toggle creation of SNS topics for feedback notifications
-      default: false
-    - field_name: notifications_bounce_topic_arn
-      type: string
-      details: ARN for an SNS topic to connect to bounce feedback notifications
-      default: ""
-    - field_name: notifications_complaint_topic_arn
-      type: string
-      details: ARN for an SNS topic to connect to complaint feedback notifications
-      default: ""
-    - field_name: notifications_delivery_topic_arn
-      type: string
-      details: ARN for an SNS topic to connect to delivery feedback notifications
+      default: true
   computed_inputs:
   - name: default_domain
     overwrite: true

--- a/smtp.yml
+++ b/smtp.yml
@@ -118,10 +118,13 @@ bind:
     details: SMTP server
   - field_name: smtp_user
     type: string
-    details: SMTP user
+    details: SMTP user and AWS Access Key ID
   - field_name: smtp_password
     type: string
     details: SMTP password
+  - field_name: secret_access_key
+    type: string
+    details: AWS Secret Access Key
 examples:
 - name: smtp
   description: SMTP base

--- a/smtp.yml
+++ b/smtp.yml
@@ -52,6 +52,21 @@ provision:
       type: string
       details: Email to recieve DMARC errors
       default: "datagovhelp@gsa.gov"
+    - field_name: create_sns_topics
+      type: boolean
+      details: Flag to toggle creation of SNS topics for feedback notifications
+      default: false
+    - field_name: notifications_bounce_topic_arn
+      type: string
+      details: ARN for an SNS topic to connect to bounce feedback notifications
+      default: ""
+    - field_name: notifications_complaint_topic_arn
+      type: string
+      details: ARN for an SNS topic to connect to complaint feedback notifications
+      default: ""
+    - field_name: notifications_delivery_topic_arn
+      type: string
+      details: ARN for an SNS topic to connect to delivery feedback notifications
   computed_inputs:
   - name: default_domain
     overwrite: true
@@ -67,6 +82,7 @@ provision:
     default: ${request.instance_id}
   template_refs:
     main: terraform/provision/main.tf
+    notification: terraform/provision/notification.tf
     outputs: terraform/provision/outputs.tf
     provider: terraform/provision/provider.tf
     variables: terraform/provision/variables.tf
@@ -87,6 +103,15 @@ provision:
   - field_name: domain_arn
     type: string
     details: Instance SES domain identity (used when creating bindings)
+  - field_name: bounce_topic_arn
+    type: string
+    details: ARN of the SNS topic receiving bounce feedback notifications
+  - field_name: complaint_topic_arn
+    type: string
+    details: ARN of the SNS topic receiving complaint feedback notifications
+  - field_name: delivery_topic_arn
+    type: string
+    details: ARN of the SNS topic receiving delivery feedback notifications
 bind:
   plan_inputs: []
   user_inputs:

--- a/smtp.yml
+++ b/smtp.yml
@@ -115,6 +115,10 @@ provision:
 bind:
   plan_inputs: []
   user_inputs:
+  - field_name: notification_webhook
+    type: string
+    details: HTTPS endpoint to subscribe to feedback notifications
+    default: ""
   computed_inputs:
   - name: region
     default: ${instance.details["region"]}
@@ -132,6 +136,18 @@ bind:
     required: true
     type: string
     default: ${request.instance_id}
+  - name: bounce_topic_arn
+    default: ${instance.details["bounce_topic_arn"]}
+    overwrite: true
+    type: string
+  - name: complaint_topic_arn
+    default: ${instance.details["complaint_topic_arn"]}
+    overwrite: true
+    type: string
+  - name: delivery_topic_arn
+    default: ${instance.details["delivery_topic_arn"]}
+    overwrite: true
+    type: string
   template_refs:
     main: terraform/bind/main.tf
     outputs: terraform/bind/outputs.tf
@@ -150,6 +166,9 @@ bind:
   - field_name: secret_access_key
     type: string
     details: AWS Secret Access Key
+  - field_name: notification_webhook
+    type: string
+    details: Subscribed endpoint for email feedback notifications
 examples:
 - name: smtp
   description: SMTP base

--- a/terraform/bind/Dockerfile
+++ b/terraform/bind/Dockerfile
@@ -1,0 +1,7 @@
+FROM hashicorp/terraform:0.13.7 as terraform
+
+RUN apk update
+RUN apk add --update git 
+
+ENTRYPOINT ["/bin/sh"]
+

--- a/terraform/bind/README.md
+++ b/terraform/bind/README.md
@@ -1,0 +1,37 @@
+# How to iterate on the binding code
+
+You can develop and test the Terraform code for binding in isolation from
+the broker context here.
+
+1. Copy `terraform.tfvars-template` to `terraform.tfvars`, then edit the content
+   appropriately. In particular, customize the `instance_name`, `user_name`
+   parameters to avoid collisions in the target AWS account!
+1. Set these three environment variables:
+
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_DEFAULT_REGION
+
+1. In order to have a development environment consistent with other
+   collaborators, we use a special Docker image with the exact CLI binaries we
+   want for testing. Doing so will avoid [discrepancies we've noted between development under OS X and W10](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1262#issuecomment-932792757).
+
+   First, build the image:
+
+    ```bash
+    docker build -t smtp-provision:latest .
+    ```
+
+1. Then, start a shell inside a container based on this image. The parameters
+   here carry some of your environment variables into that shell, and ensure
+   that you'll have permission to remove any files that get created.
+
+    ```bash
+    $ docker run -v `pwd`:`pwd` -w `pwd` -e HOME=`pwd` --user $(id -u):$(id -g) -e TERM -it --rm -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION smtp-provision:latest
+
+    [within the container]
+    terraform init
+    terraform apply -auto-approve
+    [tinker in your editor, run terraform apply, inspect the cluster, repeat]
+    terraform destroy -auto-approve
+    exit

--- a/terraform/bind/main.tf
+++ b/terraform/bind/main.tf
@@ -1,6 +1,10 @@
 locals {
   instance_id = "ses-${substr(sha256(var.instance_name), 0, 16)}"
   user_name = "${local.instance_id}-${var.user_name}"
+  subscribe_bounce_notification = (var.bounce_topic_arn != "" && var.notification_webhook != "")
+  subscribe_complaint_notification = (var.complaint_topic_arn != "" && var.notification_webhook != "")
+  subscribe_delivery_notification = (var.delivery_topic_arn != "" && var.notification_webhook != "")
+  subscribed_webhook = ((local.subscribe_bounce_notification || local.subscribe_complaint_notification || local.subscribe_delivery_notification) ? var.notification_webhook : null)
 }
 
 resource "aws_iam_user" "user" {
@@ -32,4 +36,28 @@ resource "aws_iam_user_policy" "user_policy" {
   ]
 }
 EOF
+}
+
+resource "aws_sns_topic_subscription" "bounce_subscription" {
+  count = (local.subscribe_bounce_notification ? 1 : 0)
+
+  topic_arn = var.bounce_topic_arn
+  protocol = "https"
+  endpoint = var.notification_webhook
+}
+
+resource "aws_sns_topic_subscription" "complaint_subscription" {
+  count = (local.subscribe_complaint_notification ? 1 : 0)
+
+  topic_arn = var.complaint_topic_arn
+  protocol = "https"
+  endpoint = var.notification_webhook
+}
+
+resource "aws_sns_topic_subscription" "delivery_subscription" {
+  count = (local.subscribe_delivery_notification ? 1 : 0)
+
+  topic_arn = var.delivery_topic_arn
+  protocol = "https"
+  endpoint = var.notification_webhook
 }

--- a/terraform/bind/main.tf
+++ b/terraform/bind/main.tf
@@ -1,27 +1,27 @@
 locals {
-  instance_id = "ses-${substr(sha256(var.instance_name), 0, 16)}"
-  user_name = "${local.instance_id}-${var.user_name}"
-  subscribe_bounce_notification = (var.bounce_topic_arn != "" && var.notification_webhook != "")
+  instance_id                      = "ses-${substr(sha256(var.instance_name), 0, 16)}"
+  user_name                        = "${local.instance_id}-${var.user_name}"
+  subscribe_bounce_notification    = (var.bounce_topic_arn != "" && var.notification_webhook != "")
   subscribe_complaint_notification = (var.complaint_topic_arn != "" && var.notification_webhook != "")
-  subscribe_delivery_notification = (var.delivery_topic_arn != "" && var.notification_webhook != "")
-  subscribed_webhook = ((local.subscribe_bounce_notification || local.subscribe_complaint_notification || local.subscribe_delivery_notification) ? var.notification_webhook : null)
+  subscribe_delivery_notification  = (var.delivery_topic_arn != "" && var.notification_webhook != "")
+  subscribed_webhook               = ((local.subscribe_bounce_notification || local.subscribe_complaint_notification || local.subscribe_delivery_notification) ? var.notification_webhook : null)
 }
 
 resource "aws_iam_user" "user" {
-    name = local.user_name
-    path = "/cf/"
+  name = local.user_name
+  path = "/cf/"
 }
 
 resource "aws_iam_access_key" "access_key" {
-    user = aws_iam_user.user.name
+  user = aws_iam_user.user.name
 }
 
 resource "aws_iam_user_policy" "user_policy" {
-    name   = format("%s-p", local.user_name)
+  name = format("%s-p", local.user_name)
 
-    user   = aws_iam_user.user.name
+  user = aws_iam_user.user.name
 
-    policy = <<EOF
+  policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -42,22 +42,22 @@ resource "aws_sns_topic_subscription" "bounce_subscription" {
   count = (local.subscribe_bounce_notification ? 1 : 0)
 
   topic_arn = var.bounce_topic_arn
-  protocol = "https"
-  endpoint = var.notification_webhook
+  protocol  = "https"
+  endpoint  = var.notification_webhook
 }
 
 resource "aws_sns_topic_subscription" "complaint_subscription" {
   count = (local.subscribe_complaint_notification ? 1 : 0)
 
   topic_arn = var.complaint_topic_arn
-  protocol = "https"
-  endpoint = var.notification_webhook
+  protocol  = "https"
+  endpoint  = var.notification_webhook
 }
 
 resource "aws_sns_topic_subscription" "delivery_subscription" {
   count = (local.subscribe_delivery_notification ? 1 : 0)
 
   topic_arn = var.delivery_topic_arn
-  protocol = "https"
-  endpoint = var.notification_webhook
+  protocol  = "https"
+  endpoint  = var.notification_webhook
 }

--- a/terraform/bind/outputs.tf
+++ b/terraform/bind/outputs.tf
@@ -2,3 +2,4 @@ output smtp_server { value = format("email-smtp.%s.amazonaws.com", var.region) }
 output smtp_user { value = aws_iam_access_key.access_key.id}
 output smtp_password { value = aws_iam_access_key.access_key.ses_smtp_password_v4 }
 output secret_access_key { value = aws_iam_access_key.access_key.secret }
+output notification_webhook { value = local.subscribed_webhook }

--- a/terraform/bind/outputs.tf
+++ b/terraform/bind/outputs.tf
@@ -1,5 +1,5 @@
-output smtp_server { value = format("email-smtp.%s.amazonaws.com", var.region) }
-output smtp_user { value = aws_iam_access_key.access_key.id}
-output smtp_password { value = aws_iam_access_key.access_key.ses_smtp_password_v4 }
-output secret_access_key { value = aws_iam_access_key.access_key.secret }
-output notification_webhook { value = local.subscribed_webhook }
+output "smtp_server" { value = format("email-smtp.%s.amazonaws.com", var.region) }
+output "smtp_user" { value = aws_iam_access_key.access_key.id }
+output "smtp_password" { value = aws_iam_access_key.access_key.ses_smtp_password_v4 }
+output "secret_access_key" { value = aws_iam_access_key.access_key.secret }
+output "notification_webhook" { value = local.subscribed_webhook }

--- a/terraform/bind/outputs.tf
+++ b/terraform/bind/outputs.tf
@@ -1,3 +1,4 @@
 output smtp_server { value = format("email-smtp.%s.amazonaws.com", var.region) }
 output smtp_user { value = aws_iam_access_key.access_key.id}
 output smtp_password { value = aws_iam_access_key.access_key.ses_smtp_password_v4 }
+output secret_access_key { value = aws_iam_access_key.access_key.secret }

--- a/terraform/bind/terraform.tfvars-template
+++ b/terraform/bind/terraform.tfvars-template
@@ -1,0 +1,8 @@
+region               = "us-west-2"          # Region to host SMTP server in
+instance_name        = "instance-yourname"  # Avoids collisions with others
+user_name            = "instance-user"      # Avoids collisions with others
+domain_arn           = ""                   # ARN from provisioning output
+bounce_topic_arn     = ""                   # SNS bounce topic ARN from provisioning output
+complaint_topic_arn  = ""                   # SNS complaint topic ARN from provisioning output
+delivery_topic_arn   = ""                   # SNS delivery topic ARN from provisioning output
+notification_webhook = ""                   # Webhook address to receive SNS notifications

--- a/terraform/bind/variables.tf
+++ b/terraform/bind/variables.tf
@@ -1,34 +1,34 @@
-variable user_name { type = string }
+variable "user_name" { type = string }
 
 variable "instance_name" {
   type    = string
   default = ""
 }
 
-variable region {
+variable "region" {
   type = string
 }
 
-variable domain_arn {
+variable "domain_arn" {
   type = string
 }
 
-variable bounce_topic_arn {
-  type = string
+variable "bounce_topic_arn" {
+  type    = string
   default = ""
 }
 
-variable complaint_topic_arn {
-  type = string
+variable "complaint_topic_arn" {
+  type    = string
   default = ""
 }
 
-variable delivery_topic_arn {
-  type = string
+variable "delivery_topic_arn" {
+  type    = string
   default = ""
 }
 
-variable notification_webhook {
-  type = string
+variable "notification_webhook" {
+  type    = string
   default = ""
 }

--- a/terraform/bind/variables.tf
+++ b/terraform/bind/variables.tf
@@ -5,10 +5,30 @@ variable "instance_name" {
   default = ""
 }
 
-variable region { 
-  type = string 
+variable region {
+  type = string
 }
 
 variable domain_arn {
   type = string
+}
+
+variable bounce_topic_arn {
+  type = string
+  default = ""
+}
+
+variable complaint_topic_arn {
+  type = string
+  default = ""
+}
+
+variable delivery_topic_arn {
+  type = string
+  default = ""
+}
+
+variable notification_webhook {
+  type = string
+  default = ""
 }

--- a/terraform/provision/main.tf
+++ b/terraform/provision/main.tf
@@ -71,12 +71,9 @@ locals {
   route53_records = (local.manage_domain ? local.required_records_flatter : {})
 
   # SNS topic locals
-  create_bounce_notification    = (var.create_sns_topics || var.notifications_bounce_topic_arn != "")
-  bounce_topic_sns_arn          = (var.create_sns_topics ? aws_sns_topic.bounce_topic[0].arn : var.notifications_bounce_topic_arn)
-  create_complaint_notification = (var.create_sns_topics || var.notifications_complaint_topic_arn != "")
-  complaint_topic_sns_arn       = (var.create_sns_topics ? aws_sns_topic.complaint_topic[0].arn : var.notifications_complaint_topic_arn)
-  create_delivery_notification  = (var.create_sns_topics || var.notifications_delivery_topic_arn != "")
-  delivery_topic_sns_arn        = (var.create_sns_topics ? aws_sns_topic.delivery_topic[0].arn : var.notifications_delivery_topic_arn)
+  bounce_topic_sns_arn    = (var.enable_feedback_notifications ? aws_sns_topic.bounce_topic[0].arn : "")
+  complaint_topic_sns_arn = (var.enable_feedback_notifications ? aws_sns_topic.complaint_topic[0].arn : "")
+  delivery_topic_sns_arn  = (var.enable_feedback_notifications ? aws_sns_topic.delivery_topic[0].arn : "")
 
   instructions = (local.manage_domain ? null : "Your SMTP service was provisioned, but is not yet verified. To verify your control of the ${var.domain} domain, create the 'required_records' provided here in the ${var.domain} zone before using the service.")
 }

--- a/terraform/provision/main.tf
+++ b/terraform/provision/main.tf
@@ -2,7 +2,7 @@ locals {
   instance_id = "ses-${substr(sha256(var.instance_name), 0, 16)}"
 
   manage_domain = (var.domain == "" ? true : false)
-  domain      = (local.manage_domain ? "${local.instance_id}.${var.default_domain}" : var.domain)
+  domain        = (local.manage_domain ? "${local.instance_id}.${var.default_domain}" : var.domain)
   txt_verification_record = {
     name    = "_amazonses"
     type    = "TXT"
@@ -24,34 +24,34 @@ locals {
     records = ["v=spf1 include:amazonses.com -all"]
   }
 
-  dkim_records = [ for i, token in aws_ses_domain_dkim.dkim.dkim_tokens :
+  dkim_records = [for i, token in aws_ses_domain_dkim.dkim.dkim_tokens :
     {
-      name = "${token}._domainkey.${local.domain}"
+      name    = "${token}._domainkey.${local.domain}"
       type    = "CNAME"
       ttl     = "600"
-      records = [ "${token}.dkim.amazonses.com" ]
+      records = ["${token}.dkim.amazonses.com"]
     }
   ]
 
   required_records = {
-    txt_verification_record = local.txt_verification_record
+    txt_verification_record   = local.txt_verification_record
     dmarc_verification_record = local.dmarc_verification_record
-    spf_verification_record = local.spf_verification_record
-    dkim_record_0 = local.dkim_records[0]
-    dkim_record_1 = local.dkim_records[1]
-    dkim_record_2 = local.dkim_records[2]
+    spf_verification_record   = local.spf_verification_record
+    dkim_record_0             = local.dkim_records[0]
+    dkim_record_1             = local.dkim_records[1]
+    dkim_record_2             = local.dkim_records[2]
   }
 
   # Generate string output usable for pasting into HCL elsewhere if needed
   required_records_as_string = <<-EOT
 
-  {%{ for key, value in local.required_records }
+  {%{for key, value in local.required_records}
     ${key} = {
       name    = "${value.name}"
       type    = "${value.type}"
       ttl     = "${value.ttl}"
-      records = [%{ for record in value.records }"${record}"%{ endfor ~}]
-    } %{ endfor }
+      records = [%{for record in value.records}"${record}"%{endfor~}]
+    } %{endfor}
   }
   EOT
 
@@ -60,10 +60,10 @@ locals {
   required_records_flatter = {
     for key, value in local.required_records :
     key => {
-      id = key
-      name = value.name
-      type = value.type
-      ttl = value.ttl
+      id     = key
+      name   = value.name
+      type   = value.type
+      ttl    = value.ttl
       record = value.records[0]
     }
   }
@@ -71,12 +71,12 @@ locals {
   route53_records = (local.manage_domain ? local.required_records_flatter : {})
 
   # SNS topic locals
-  create_bounce_notification = (var.create_sns_topics || var.notifications_bounce_topic_arn != "")
-  bounce_topic_sns_arn = (var.create_sns_topics ? aws_sns_topic.bounce_topic[0].arn : var.notifications_bounce_topic_arn)
+  create_bounce_notification    = (var.create_sns_topics || var.notifications_bounce_topic_arn != "")
+  bounce_topic_sns_arn          = (var.create_sns_topics ? aws_sns_topic.bounce_topic[0].arn : var.notifications_bounce_topic_arn)
   create_complaint_notification = (var.create_sns_topics || var.notifications_complaint_topic_arn != "")
-  complaint_topic_sns_arn = (var.create_sns_topics ? aws_sns_topic.complaint_topic[0].arn : var.notifications_complaint_topic_arn)
-  create_delivery_notification = (var.create_sns_topics || var.notifications_delivery_topic_arn != "")
-  delivery_topic_sns_arn = (var.create_sns_topics ? aws_sns_topic.delivery_topic[0].arn : var.notifications_delivery_topic_arn)
+  complaint_topic_sns_arn       = (var.create_sns_topics ? aws_sns_topic.complaint_topic[0].arn : var.notifications_complaint_topic_arn)
+  create_delivery_notification  = (var.create_sns_topics || var.notifications_delivery_topic_arn != "")
+  delivery_topic_sns_arn        = (var.create_sns_topics ? aws_sns_topic.delivery_topic[0].arn : var.notifications_delivery_topic_arn)
 
   instructions = (local.manage_domain ? null : "Your SMTP service was provisioned, but is not yet verified. To verify your control of the ${var.domain} domain, create the 'required_records' provided here in the ${var.domain} zone before using the service.")
 }

--- a/terraform/provision/notification.tf
+++ b/terraform/provision/notification.tf
@@ -1,44 +1,44 @@
 # Create SNS topic for bounce messages
 resource "aws_sns_topic" "bounce_topic" {
   count = (var.create_sns_topics ? 1 : 0)
-  name = "${var.instance_name}-bounce"
+  name  = "${var.instance_name}-bounce"
 }
 
 # Connect bounce notifications to the bounce SNS topic
 resource "aws_ses_identity_notification_topic" "bounce" {
-  count = (local.create_bounce_notification ? 1 : 0)
-  topic_arn = local.bounce_topic_sns_arn
-  notification_type = "Bounce"
-  identity = aws_ses_domain_identity.identity.arn
+  count                    = (local.create_bounce_notification ? 1 : 0)
+  topic_arn                = local.bounce_topic_sns_arn
+  notification_type        = "Bounce"
+  identity                 = aws_ses_domain_identity.identity.arn
   include_original_headers = true
 }
 
 # Create SNS topic for complaint messages
 resource "aws_sns_topic" "complaint_topic" {
   count = (var.create_sns_topics ? 1 : 0)
-  name = "${var.instance_name}-complaint"
+  name  = "${var.instance_name}-complaint"
 }
 
 # Connect complaint notifications to the complaint SNS topic
 resource "aws_ses_identity_notification_topic" "complaint" {
-  count = (local.create_complaint_notification ? 1 : 0)
-  topic_arn = local.complaint_topic_sns_arn
-  notification_type = "Complaint"
-  identity = aws_ses_domain_identity.identity.arn
+  count                    = (local.create_complaint_notification ? 1 : 0)
+  topic_arn                = local.complaint_topic_sns_arn
+  notification_type        = "Complaint"
+  identity                 = aws_ses_domain_identity.identity.arn
   include_original_headers = true
 }
 
 # Create SNS topic for delivery messages
 resource "aws_sns_topic" "delivery_topic" {
   count = (var.create_sns_topics ? 1 : 0)
-  name = "${var.instance_name}-delivery"
+  name  = "${var.instance_name}-delivery"
 }
 
 # Connect delivery notifications to the delivery SNS topic
 resource "aws_ses_identity_notification_topic" "delivery" {
-  count = (local.create_delivery_notification ? 1 : 0)
-  topic_arn = local.delivery_topic_sns_arn
-  notification_type = "Delivery"
-  identity = aws_ses_domain_identity.identity.arn
+  count                    = (local.create_delivery_notification ? 1 : 0)
+  topic_arn                = local.delivery_topic_sns_arn
+  notification_type        = "Delivery"
+  identity                 = aws_ses_domain_identity.identity.arn
   include_original_headers = true
 }

--- a/terraform/provision/notification.tf
+++ b/terraform/provision/notification.tf
@@ -1,13 +1,13 @@
 # Create SNS topic for bounce messages
 resource "aws_sns_topic" "bounce_topic" {
-  count = (var.create_sns_topics ? 1 : 0)
+  count = (var.enable_feedback_notifications ? 1 : 0)
   name  = "${var.instance_name}-bounce"
 }
 
 # Connect bounce notifications to the bounce SNS topic
 resource "aws_ses_identity_notification_topic" "bounce" {
-  count                    = (local.create_bounce_notification ? 1 : 0)
-  topic_arn                = local.bounce_topic_sns_arn
+  count                    = (var.enable_feedback_notifications ? 1 : 0)
+  topic_arn                = aws_sns_topic.bounce_topic[0].arn
   notification_type        = "Bounce"
   identity                 = aws_ses_domain_identity.identity.arn
   include_original_headers = true
@@ -15,14 +15,14 @@ resource "aws_ses_identity_notification_topic" "bounce" {
 
 # Create SNS topic for complaint messages
 resource "aws_sns_topic" "complaint_topic" {
-  count = (var.create_sns_topics ? 1 : 0)
+  count = (var.enable_feedback_notifications ? 1 : 0)
   name  = "${var.instance_name}-complaint"
 }
 
 # Connect complaint notifications to the complaint SNS topic
 resource "aws_ses_identity_notification_topic" "complaint" {
-  count                    = (local.create_complaint_notification ? 1 : 0)
-  topic_arn                = local.complaint_topic_sns_arn
+  count                    = (var.enable_feedback_notifications ? 1 : 0)
+  topic_arn                = aws_sns_topic.complaint_topic[0].arn
   notification_type        = "Complaint"
   identity                 = aws_ses_domain_identity.identity.arn
   include_original_headers = true
@@ -30,14 +30,14 @@ resource "aws_ses_identity_notification_topic" "complaint" {
 
 # Create SNS topic for delivery messages
 resource "aws_sns_topic" "delivery_topic" {
-  count = (var.create_sns_topics ? 1 : 0)
+  count = (var.enable_feedback_notifications ? 1 : 0)
   name  = "${var.instance_name}-delivery"
 }
 
 # Connect delivery notifications to the delivery SNS topic
 resource "aws_ses_identity_notification_topic" "delivery" {
-  count                    = (local.create_delivery_notification ? 1 : 0)
-  topic_arn                = local.delivery_topic_sns_arn
+  count                    = (var.enable_feedback_notifications ? 1 : 0)
+  topic_arn                = aws_sns_topic.delivery_topic[0].arn
   notification_type        = "Delivery"
   identity                 = aws_ses_domain_identity.identity.arn
   include_original_headers = true

--- a/terraform/provision/notification.tf
+++ b/terraform/provision/notification.tf
@@ -1,0 +1,44 @@
+# Create SNS topic for bounce messages
+resource "aws_sns_topic" "bounce_topic" {
+  count = (var.create_sns_topics ? 1 : 0)
+  name = "${var.instance_name}-bounce"
+}
+
+# Connect bounce notifications to the bounce SNS topic
+resource "aws_ses_identity_notification_topic" "bounce" {
+  count = (local.create_bounce_notification ? 1 : 0)
+  topic_arn = local.bounce_topic_sns_arn
+  notification_type = "Bounce"
+  identity = aws_ses_domain_identity.identity.arn
+  include_original_headers = true
+}
+
+# Create SNS topic for complaint messages
+resource "aws_sns_topic" "complaint_topic" {
+  count = (var.create_sns_topics ? 1 : 0)
+  name = "${var.instance_name}-complaint"
+}
+
+# Connect complaint notifications to the complaint SNS topic
+resource "aws_ses_identity_notification_topic" "complaint" {
+  count = (local.create_complaint_notification ? 1 : 0)
+  topic_arn = local.complaint_topic_sns_arn
+  notification_type = "Complaint"
+  identity = aws_ses_domain_identity.identity.arn
+  include_original_headers = true
+}
+
+# Create SNS topic for delivery messages
+resource "aws_sns_topic" "delivery_topic" {
+  count = (var.create_sns_topics ? 1 : 0)
+  name = "${var.instance_name}-delivery"
+}
+
+# Connect delivery notifications to the delivery SNS topic
+resource "aws_ses_identity_notification_topic" "delivery" {
+  count = (local.create_delivery_notification ? 1 : 0)
+  topic_arn = local.delivery_topic_sns_arn
+  notification_type = "Delivery"
+  identity = aws_ses_domain_identity.identity.arn
+  include_original_headers = true
+}

--- a/terraform/provision/outputs.tf
+++ b/terraform/provision/outputs.tf
@@ -1,29 +1,29 @@
-output region { value = var.region }
+output "region" { value = var.region }
 
-output required_records {
+output "required_records" {
   value = local.manage_domain ? null : local.required_records_as_string
 }
 
-output email_receipt_error {
-    value = var.email_receipt_error
+output "email_receipt_error" {
+  value = var.email_receipt_error
 }
 
-output instructions {
+output "instructions" {
   value = local.instructions
 }
 
-output domain_arn {
+output "domain_arn" {
   value = aws_ses_domain_identity.identity.arn
 }
 
-output bounce_topic_arn {
+output "bounce_topic_arn" {
   value = (local.bounce_topic_sns_arn == "" ? null : local.bounce_topic_sns_arn)
 }
 
-output complaint_topic_arn {
+output "complaint_topic_arn" {
   value = (local.complaint_topic_sns_arn == "" ? null : local.complaint_topic_sns_arn)
 }
 
-output delivery_topic_arn {
+output "delivery_topic_arn" {
   value = (local.delivery_topic_sns_arn == "" ? null : local.delivery_topic_sns_arn)
 }

--- a/terraform/provision/outputs.tf
+++ b/terraform/provision/outputs.tf
@@ -17,13 +17,13 @@ output "domain_arn" {
 }
 
 output "bounce_topic_arn" {
-  value = (local.bounce_topic_sns_arn == "" ? null : local.bounce_topic_sns_arn)
+  value = local.bounce_topic_sns_arn
 }
 
 output "complaint_topic_arn" {
-  value = (local.complaint_topic_sns_arn == "" ? null : local.complaint_topic_sns_arn)
+  value = local.complaint_topic_sns_arn
 }
 
 output "delivery_topic_arn" {
-  value = (local.delivery_topic_sns_arn == "" ? null : local.delivery_topic_sns_arn)
+  value = local.delivery_topic_sns_arn
 }

--- a/terraform/provision/outputs.tf
+++ b/terraform/provision/outputs.tf
@@ -15,3 +15,15 @@ output instructions {
 output domain_arn {
   value = aws_ses_domain_identity.identity.arn
 }
+
+output bounce_topic_arn {
+  value = (local.bounce_topic_sns_arn == "" ? null : local.bounce_topic_sns_arn)
+}
+
+output complaint_topic_arn {
+  value = (local.complaint_topic_sns_arn == "" ? null : local.complaint_topic_sns_arn)
+}
+
+output delivery_topic_arn {
+  value = (local.delivery_topic_sns_arn == "" ? null : local.delivery_topic_sns_arn)
+}

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -27,26 +27,8 @@ variable "labels" {
   default = {}
 }
 
-variable "create_sns_topics" {
+variable "enable_feedback_notifications" {
   type        = bool
   description = "Toggle whether to create SNS topics for feedback notifications"
-  default     = false
-}
-
-variable "notifications_bounce_topic_arn" {
-  type        = string
-  description = "ARN of an SNS topic to subscribe bounce messages to"
-  default     = ""
-}
-
-variable "notifications_complaint_topic_arn" {
-  type        = string
-  description = "ARN of an SNS topic to subscribe complaint messages to"
-  default     = ""
-}
-
-variable "notifications_delivery_topic_arn" {
-  type        = string
-  description = "ARN of an SNS topic to subscribe delivery messages to"
-  default     = ""
+  default     = true
 }

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -11,7 +11,7 @@ variable "default_domain" {
 }
 
 variable "instance_name" {
-  type    = string
+  type = string
 }
 
 variable "region" {
@@ -28,25 +28,25 @@ variable "labels" {
 }
 
 variable "create_sns_topics" {
-  type = bool
+  type        = bool
   description = "Toggle whether to create SNS topics for feedback notifications"
-  default = false
+  default     = false
 }
 
 variable "notifications_bounce_topic_arn" {
-  type = string
+  type        = string
   description = "ARN of an SNS topic to subscribe bounce messages to"
-  default = ""
+  default     = ""
 }
 
 variable "notifications_complaint_topic_arn" {
-  type = string
+  type        = string
   description = "ARN of an SNS topic to subscribe complaint messages to"
-  default = ""
+  default     = ""
 }
 
 variable "notifications_delivery_topic_arn" {
-  type = string
+  type        = string
   description = "ARN of an SNS topic to subscribe delivery messages to"
-  default = ""
+  default     = ""
 }

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -26,3 +26,27 @@ variable "labels" {
   type    = map(any)
   default = {}
 }
+
+variable "create_sns_topics" {
+  type = bool
+  description = "Toggle whether to create SNS topics for feedback notifications"
+  default = false
+}
+
+variable "notifications_bounce_topic_arn" {
+  type = string
+  description = "ARN of an SNS topic to subscribe bounce messages to"
+  default = ""
+}
+
+variable "notifications_complaint_topic_arn" {
+  type = string
+  description = "ARN of an SNS topic to subscribe complaint messages to"
+  default = ""
+}
+
+variable "notifications_delivery_topic_arn" {
+  type = string
+  description = "ARN of an SNS topic to subscribe delivery messages to"
+  default = ""
+}

--- a/terraform/provision/verification.tf
+++ b/terraform/provision/verification.tf
@@ -35,7 +35,7 @@ resource "aws_route53_record" "records" {
   name    = each.value.name
   type    = each.value.type
   ttl     = each.value.ttl
-  records = [ each.value.record ]
+  records = [each.value.record]
 
   zone_id = aws_route53_zone.instance_zone[0].zone_id
 }


### PR DESCRIPTION
Added a couple of features to the SES brokerpak:

1) Include `AWS_SECRET_ACCESS_KEY` to bind output, to support sending email via API in addition to SMTP
2) Optionally setup Notification Feedback channels, to be notified about Bounce, Complaint, and Delivery events.
  * Optionally create these SNS channels as part of provision (defaults to true, but can be turned off)
  * Optionally subscribe an HTTPS webhook to the SNS channels as part of the bind.