### PR TITLE
Enable Custom MAIL FROM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ demo-up-supplied: ## Provision an SMTP instance and output the bound credentials
 	set -e ;\
 	eval "$$( $(CSB_SET_IDS) )" ;\
 	echo "Provisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
-	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params '{ "domain": "test.com", "enable_feedback_notifications": false }' 2>&1 > ${INSTANCE_NAME}.provisioning.txt ;\
+	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params '{ "domain": "test.com", "enable_feedback_notifications": false, "mail_from_subdomain": "mail" }' 2>&1 > ${INSTANCE_NAME}.provisioning.txt ;\
 	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} ;\
 	echo "Binding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding2" ;\
 	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding2 --params '{}' | jq -r .response > ${INSTANCE_NAME}.binding.json ;\

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Each brokered AWS SES instance provides:
   - DNS records necessary for verifying domain ownership (TXT and DKIM)
   - Bounce, Complaint, and Delivery notifications can be sent to your server. See [Delivery Notifications](#delivery-notifications) for instructions
 
+### Custom MAIL FROM
+
+The broker can set up a [custom MAIL FROM](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html) by passing in the `mail_from_subdomain` variable value.
+
+This should just be the subdomain that mail will appear to be coming from and will be prepended to your given `domain`.
+
+The provision outputs will include the required DNS records to validate this setting in the `required_records` output.
+
 ### Delivery Notifications
 
 [SES Delivery Notifications](https://docs.aws.amazon.com/ses/latest/dg/monitor-sending-activity-using-notifications-sns.html) can be configured by:

--- a/smtp.yml
+++ b/smtp.yml
@@ -57,6 +57,10 @@ provision:
       type: boolean
       details: Flag to toggle creation of SNS topics for feedback notifications
       default: false
+    - field_name: mail_from_subdomain
+      type: string
+      details: Subdomain to use as sending email server
+      default: ""
   computed_inputs:
   - name: default_domain
     overwrite: true

--- a/terraform/provision/terraform.tfvars-template
+++ b/terraform/provision/terraform.tfvars-template
@@ -1,5 +1,6 @@
 region              = "us-west-2"               # Region to host SMTP server in
-domain              = ""                        # Custom domain 
+domain              = ""                        # Custom domain
 default_domain      = "ssb-dev.data.gov"        # Domain under which to create a domain if none was supplied
 instance_name       = "instance-yourname"       # Avoids collisions with others
 email_receipt_error = "youraddress@yourdomain"  # Address where notification of email recipt errors should be sent
+mail_from_subdomain = "mail"

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -32,3 +32,9 @@ variable "enable_feedback_notifications" {
   description = "Toggle whether to create SNS topics for feedback notifications"
   default     = false
 }
+
+variable "mail_from_subdomain" {
+  type        = string
+  description = "Subdomain to set as the mail-from value"
+  default     = ""
+}

--- a/terraform/provision/verification.tf
+++ b/terraform/provision/verification.tf
@@ -1,4 +1,4 @@
-# Get the configured default DNS Zone 
+# Get the configured default DNS Zone
 data "aws_route53_zone" "parent_zone" {
   count = (local.manage_domain ? 1 : 0)
   name  = var.default_domain
@@ -36,6 +36,18 @@ resource "aws_route53_record" "records" {
   type    = each.value.type
   ttl     = each.value.ttl
   records = [each.value.record]
+
+  zone_id = aws_route53_zone.instance_zone[0].zone_id
+}
+
+# Create MX record if needed
+resource "aws_route53_record" "mail_from_mx_record" {
+  count = (local.manage_domain && local.setting_mail_from ? 1 : 0)
+
+  name    = local.mx_verification_record.name
+  type    = local.mx_verification_record.type
+  ttl     = local.mx_verification_record.ttl
+  records = local.mx_verification_record.records
 
   zone_id = aws_route53_zone.instance_zone[0].zone_id
 }


### PR DESCRIPTION
This change enables optionally setting the [MAIL FROM](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html) for SES domains.

This is a backwards-compatible change because:

1) no changes to IAM rules
2) New `mail_from_subdomain` provision input has a default value that does not change existing infrastructure
3) If any output changes, it is an additional entry in the existing `required_records` provisioning output

Because `mx_verification_record` is not always created, I couldn't add it to the `required_records` local variable or there were weird race conditions on initial creation that required `-target` to address.

closes #22 