### PR TITLE
Remove eden install step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,6 @@ jobs:
         shell: bash
 
     steps:
-    - name: Install the eden OSBAPI CLI tool
-      run: |
-        wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | sudo apt-key add -
-        echo "deb http://apt.starkandwayne.com stable main" | sudo tee /etc/apt/sources.list.d/starkandwayne.list
-        sudo apt-get update
-        sudo apt-get install eden
     - name: Install checkdmarc
       run: |
         pip install checkdmarc==4.4.2


### PR DESCRIPTION
Looks like eden was removed from the code in #14 but this use was missed.

It wasn't hurting anything before, but the release has failed a couple times because it wasn't able to install.