### PR TITLE
Put sourceIP condition on brokerpak-created credentials

### DIFF
--- a/smtp.yml
+++ b/smtp.yml
@@ -108,6 +108,13 @@ provision:
 bind:
   plan_inputs: []
   user_inputs:
+  - field_name: source_ips
+    type: array
+    default:
+    - 52.222.122.97/32
+    - 52.222.123.172/32
+    details: IP Ranges that requests to SES must come from
+    prohibit_update: false
   - field_name: notification_webhook
     type: string
     details: HTTPS endpoint to subscribe to feedback notifications

--- a/terraform/bind/main.tf
+++ b/terraform/bind/main.tf
@@ -21,21 +21,22 @@ resource "aws_iam_user_policy" "user_policy" {
 
   user = aws_iam_user.user.name
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action":[
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
         "ses:SendEmail",
         "ses:SendRawEmail"
-      ],
-      "Resource": "${var.domain_arn}"
-    }
-  ]
-}
-EOF
+      ]
+      Resource = var.domain_arn
+      Condition = {
+        "ForAnyValue:IpAddress" = {
+          "aws:SourceIp" = var.source_ips
+        }
+      }
+    }]
+  })
 }
 
 resource "aws_sns_topic_subscription" "bounce_subscription" {

--- a/terraform/bind/terraform.tfvars-template
+++ b/terraform/bind/terraform.tfvars-template
@@ -6,3 +6,7 @@ bounce_topic_arn     = ""                   # SNS bounce topic ARN from provisio
 complaint_topic_arn  = ""                   # SNS complaint topic ARN from provisioning output
 delivery_topic_arn   = ""                   # SNS delivery topic ARN from provisioning output
 notification_webhook = ""                   # Webhook address to receive SNS notifications
+source_ips = [
+  "52.222.122.97/32",
+  "52.222.123.172/32"
+]

--- a/terraform/bind/variables.tf
+++ b/terraform/bind/variables.tf
@@ -13,6 +13,10 @@ variable "domain_arn" {
   type = string
 }
 
+variable "source_ips" {
+  type = list(string)
+}
+
 variable "bounce_topic_arn" {
   type    = string
   default = ""


### PR DESCRIPTION
Defaults to [cloud.gov egress IPs](https://cloud.gov/docs/management/static-egress/#cloudgov-egress-ranges), but can be overridden in bind parameters.

This shouldn't have any effect on already-bound apps, but does make new bindings limited to cloud.gov use without adding an additional bind parameter, so not purely backwards compatible.